### PR TITLE
challenges: fix guideline URLs

### DIFF
--- a/challenges/1-first-blood.md
+++ b/challenges/1-first-blood.md
@@ -8,4 +8,4 @@ Once you're done, push your branch to the remote and open a Pull Request (PR) ag
 
 This will help you practice the basic workflow of contributing to a shared repo.
 
-[Guidelines and docs](../section/01-the-usual-git-flow.md)
+[Guidelines and docs](../sections/01-the-usual-git-flow.md)

--- a/challenges/2-know-your-history.md
+++ b/challenges/2-know-your-history.md
@@ -14,4 +14,4 @@ You’ll need to configure this alias using  `git config` or by editing `~/.gitc
 
 Instead of using the cluttered `git log`, you can now use your brand new `git hist` to check the older commits.
 
-[Guidelines and docs](../section/02-make-yourself-at-home.md)
+[Guidelines and docs](../sections/02-make-yourself-at-home.md)

--- a/challenges/3-hide-under-the-carpet.md
+++ b/challenges/3-hide-under-the-carpet.md
@@ -12,4 +12,4 @@ Follow the steps below to master stashing:
 6. Pop and apply stashes to bring your changes back into the working directory.
 7. Selectively apply or drop specific stashes using their stash@{n} references.
 
-[Guidelines and docs](../section/03-mastering-git-stash.md)
+[Guidelines and docs](../sections/03-mastering-git-stash.md)

--- a/challenges/4-gather-cherries.md
+++ b/challenges/4-gather-cherries.md
@@ -11,4 +11,4 @@ Explore the branches `living_room`, `basement`, `terrace` and the commits ahead 
 
 Each branch contains a few commits that are ahead of main. Your task is to bring all those changes together by cherry-picking the commits onto the main branch — without merging the branches themselves.
 
-[Guidelines and docs](../section/04-hot-fixing-in-production.md)
+[Guidelines and docs](../sections/04-hot-fixing-in-production.md)

--- a/challenges/5-repair-your-mistakes.md
+++ b/challenges/5-repair-your-mistakes.md
@@ -19,4 +19,4 @@ Use `git rebase -i` to have the following history only:
 
 You’ll need to reorder, squash, and edit commit messages during the rebase to achieve this clean structure. When done, check the log to confirm the history matches the desired format.
 
-[Guidelines and docs](../section/05-code-review-shenanigans.md)
+[Guidelines and docs](../sections/05-code-review-shenanigans.md)

--- a/challenges/6-it-is-elementary-watson.md
+++ b/challenges/6-it-is-elementary-watson.md
@@ -11,4 +11,4 @@ Explore the commits: The repository has multiple commits that progressively modi
 
 Use `git bissect` to identify the commit that contains the flag.
 
-[Guidelines and docs](../section/06-who-dafaq-wrote-this-oh-its-me.md)
+[Guidelines and docs](../sections/06-who-dafaq-wrote-this-oh-its-me.md)

--- a/challenges/8.1-set-the-keys.md
+++ b/challenges/8.1-set-the-keys.md
@@ -19,5 +19,5 @@ git remote set-url origin git@github.com:andreia-oca/git_good_workshop.git
 git remote -v
 ```
 
-[Guidelines and docs](../section/08-advanced-settings.md)
+[Guidelines and docs](../sections/08-advanced-settings.md)
 f

--- a/challenges/8.2-automate-chores.md
+++ b/challenges/8.2-automate-chores.md
@@ -16,4 +16,4 @@ Test your hook by making several commits with valid and invalid messages to conf
 
 Tip: This hook runs automatically every time you make a commit, so it’s a great way to enforce standards without manual review.
 
-[Guidelines and docs](../section/08-advanced-settings.md)
+[Guidelines and docs](../sections/08-advanced-settings.md)


### PR DESCRIPTION
It seems there is a typo in the challenges, where they poin to the '../section/' folder, vs the '../sections/' folder in the tree.

This change updates all URLs to the correct folder.